### PR TITLE
edit:추억 마커 선택 시 주소 표현 수정

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -28,6 +28,7 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    //DB 저장 되어있는 정보들을 앱 시작전에 불러오기
     context.read<MarkerProvider>().fetchMarkers();
     context.read<MemoryProvider>().fetchMemory();
     context.read<PictureProvider>().fetchPicutre();

--- a/lib/screens/marker_list_screen.dart
+++ b/lib/screens/marker_list_screen.dart
@@ -32,6 +32,8 @@ class _MarkerListScreenState extends State<MarkerListScreen> {
               onTap: () {
                 var latLng = LatLng(markers[index].lati, markers[index].longi);
                 moveToLatLng(latLng);
+                //해당 마커를 눌렀을 때 가리키고 있는 marker를 변경해줌.
+                Provider.of<MarkerProvider>(context, listen: false).updateCurrentMarker(markers[index]);
                 Navigator.pop(context);
                 Future.delayed(const Duration(milliseconds: 120));
               },

--- a/lib/utils/add_marker.dart
+++ b/lib/utils/add_marker.dart
@@ -351,6 +351,8 @@ class _CustomDialogState extends State<CustomDialog> {
       await Provider.of<MarkerProvider>(context, listen: false)
           .addMarker(newMarker);
 
+      Provider.of<MarkerProvider>(context).updateCurrentMarker(newMarker);
+
       // 마커 정보를 불러온다.
 
       // 마커 맵에 불러온 마커를 추가한다.

--- a/lib/utils/add_marker.dart
+++ b/lib/utils/add_marker.dart
@@ -351,7 +351,7 @@ class _CustomDialogState extends State<CustomDialog> {
       await Provider.of<MarkerProvider>(context, listen: false)
           .addMarker(newMarker);
 
-      Provider.of<MarkerProvider>(context).updateCurrentMarker(newMarker);
+      Provider.of<MarkerProvider>(context, listen: false).updateCurrentMarker(newMarker);
 
       // 마커 정보를 불러온다.
 

--- a/lib/utils/address_search.dart
+++ b/lib/utils/address_search.dart
@@ -3,6 +3,8 @@ import 'package:kakao_map_plugin/kakao_map_plugin.dart';
 import 'package:kpostal/kpostal.dart';
 import 'package:my_tiny_map/datas/models/kakaomap_model.dart';
 import 'package:my_tiny_map/utils/kakao.dart';
+import 'package:provider/provider.dart';
+import 'package:my_tiny_map/view_model/marker_provider.dart';
 
 class AddressSearch extends StatefulWidget {
   const AddressSearch({super.key});
@@ -24,8 +26,12 @@ class _AddressSearchState extends State<AddressSearch> {
       right: 15,
       child: GestureDetector(
         onTap: () async {
+          //아무 결과도 없이 뒤로 가기 처리 위함.
+          getL.roadAddress='-';
           await onTap();
-          await moveLocation();
+          print(getL.roadAddress);
+          if(getL.roadAddress!='-')
+            await moveLocation();
         },
         child: Container(
           decoration: BoxDecoration(
@@ -52,22 +58,33 @@ class _AddressSearchState extends State<AddressSearch> {
                     children: [
                       const Icon(Icons.search),
                       const SizedBox(width: 12),
-                      getL.roadAddress != '-'
-                          ? Text(
-                              getL.roadAddress,
-                              style: TextStyle(
-                                fontWeight: FontWeight.bold,
-                                fontSize: 18.0,
-                                color: Colors.grey.shade800,
-                              ),
-                            )
-                          : Text(
-                              '검색할 내용을 입력해주세요.',
-                              style: TextStyle(
-                                color: Colors.grey[600],
-                                fontSize: 16.0,
-                              ),
+                      //가리키고있는 마커와 상관없이, 검색결과에서 찾고자 하는 위치를 callback 하였을 때
+                      if(getL.roadAddress != '-' )
+                          Text( getL.roadAddress,
+                            style: TextStyle(
+                              fontWeight: FontWeight.bold,
+                              fontSize: 18.0,
+                              color: Colors.grey.shade800,
                             ),
+                          )
+                      else
+                          Provider.of<MarkerProvider>(context).currentMarker != null ?
+                          Text(
+                            Provider.of<MarkerProvider>(context).currentMarker!.place.toString(),
+                            style: TextStyle(
+                              fontWeight: FontWeight.bold,
+                              fontSize: 18.0,
+                              color: Colors.grey.shade800,
+                            ),
+                          ) :
+                          //현재 가리키고 있는 마커가 존재한데, 검색하다가 뒤로 가기 눌렀을 때
+                          Text(
+                            '검색할 내용을 입력해주세요.',
+                            style: TextStyle(
+                              color: Colors.grey[600],
+                              fontSize: 16.0,
+                            ),
+                          ),
                     ],
                   ),
                 ),
@@ -104,10 +121,12 @@ class _AddressSearchState extends State<AddressSearch> {
 
   Future moveLocation() async {
     // 딜레이가 없으면 검색된 위도,경도의 값이 반영되지 않아 검색 후 딜레이를 주어서 반영되게 함
-    await Future.delayed(const Duration(milliseconds: 12000), () {
+    await Future.delayed(const Duration(milliseconds: 4000), () {
       mapController.setCenter(LatLng(getL.init_latitude, getL.init_longitude));
 
       // 검색 후 마커 찍음
+      // 검색 후에 위치를 db에 추가하는게 아닌, 지도상에서만 marker를 추가하기에, 해당 마커를 눌렀을때의 작동이 정의되어있지 않음.
+      /*
       marker = Marker(
         markerId: markers.length.toString(),
         latLng: LatLng(getL.init_latitude, getL.init_longitude),
@@ -116,12 +135,14 @@ class _AddressSearchState extends State<AddressSearch> {
         offsetX: 15,
         offsetY: 44,
         // markerImageSrc: 'https://w7.pngwing.com/pngs/96/889/png-transparent-marker-map-interesting-places-the-location-on-the-map-the-location-of-the-thumbnail.png',
-      ); /*
+      );*/ /*
       double _a = double.parse(getL.init_latitude.toStringAsFixed(6));
       double _b = double.parse(getL.init_longitude.toStringAsFixed(6));
       SqlMarkerCRUD().insert(getL.roadAddress,_a,_b);*/
+      /*
       markers.add(marker);
       mapController.addMarker(markers: markers.toList());
+      */
     });
   }
 }

--- a/lib/utils/address_search.dart
+++ b/lib/utils/address_search.dart
@@ -68,7 +68,7 @@ class _AddressSearchState extends State<AddressSearch> {
                             ),
                           )
                       else
-                          Provider.of<MarkerProvider>(context).currentMarker != null ?
+                        (Provider.of<MarkerProvider>(context).currentMarker != null && Provider.of<MarkerProvider>(context).currentMarker!.place != '-') ?
                           Text(
                             Provider.of<MarkerProvider>(context).currentMarker!.place.toString(),
                             style: TextStyle(

--- a/lib/utils/kakao.dart
+++ b/lib/utils/kakao.dart
@@ -60,7 +60,8 @@ class _BuildkakaoMapState extends State<BuildkakaoMap> {
           markerId: markerModel.id.toString(),
           latLng: LatLng(markerModel.lati, markerModel.longi),
           width: 24,
-          height: 36));
+          height: 36)
+      );
     }
 
     Future.delayed(const Duration(milliseconds: 200));

--- a/lib/utils/show_memory.dart
+++ b/lib/utils/show_memory.dart
@@ -263,6 +263,7 @@ Future _showDialogMarker(context) {
                   //  .deleteMarker(deletedMarkerId!);
                   context.read<MarkerProvider>().deleteMarker(deletedMarkerId!);
                   selectedMarkerProvider.initSelectedMarker();
+                  context.read<MarkerProvider>().initCurrentMarker();
 
                   Navigator.pop(context);
                   Navigator.pop(context);

--- a/lib/view_model/marker_provider.dart
+++ b/lib/view_model/marker_provider.dart
@@ -9,6 +9,13 @@ class MarkerProvider extends ChangeNotifier {
 
   List<MarkerModel> get markers => _markers;
 
+  MarkerModel? currentMarker;
+
+  void updateCurrentMarker(MarkerModel marker) {
+    currentMarker = marker;
+    notifyListeners();
+  }
+
   Future<void> addMarker(MarkerModel marker) async {
     marker.id = await _sqlMarkerCRUD.markerModelInsert(marker);
     _markers.add(marker);

--- a/lib/view_model/marker_provider.dart
+++ b/lib/view_model/marker_provider.dart
@@ -16,6 +16,11 @@ class MarkerProvider extends ChangeNotifier {
     notifyListeners();
   }
 
+  void initCurrentMarker() {
+    currentMarker!.place = '-';
+    notifyListeners();
+  }
+
   Future<void> addMarker(MarkerModel marker) async {
     marker.id = await _sqlMarkerCRUD.markerModelInsert(marker);
     _markers.add(marker);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -53,10 +53,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.1"
+    version: "1.18.0"
   convert:
     dependency: transitive
     description:
@@ -428,18 +428,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
+      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.15"
+    version: "0.12.16"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.5.0"
   meta:
     dependency: transitive
     description:
@@ -577,10 +577,10 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
   sqflite:
     dependency: "direct main"
     description:
@@ -601,18 +601,18 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   string_scanner:
     dependency: transitive
     description:
@@ -641,10 +641,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
+      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "0.6.1"
   typed_data:
     dependency: transitive
     description:
@@ -677,6 +677,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.4-beta"
   webview_flutter:
     dependency: transitive
     description:
@@ -742,5 +750,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.0.0 <4.0.0"
+  dart: ">=3.1.0-185.0.dev <4.0.0"
   flutter: ">=3.3.0"


### PR DESCRIPTION
## 설명

<!--
이 PR이 merge 될 때 사용할 설명을 적어주세요. [Writing a good PR description](https://www.pullrequest.com/blog/writing-a-great-pull-request-description)을 참조해주세요.
-->
1. 주소 검색 시 메인화면의 주소 검색에 현재 검색한 주소가 나타나게 변경
2. 마커 선택 & 추가 시, 선택한 마커의 주소가 주소 검색에 나타나도록 수정
3. 마커 삭제 후 주소 검색창 초기화

## 데모

<!--
영상이나 스크린샷 등으로 부연 설명을 해주세요.
-->

![K-003](https://github.com/toy-p/Pocket-Map/assets/110343070/80b05301-a07b-4ec2-8a32-1cb9dae009b0)


![K-006](https://github.com/toy-p/Pocket-Map/assets/110343070/095cc702-53c0-4cee-8a58-94905180307d)
-> 마커 추가 후 좌표 이동 변화 딜레이는 duration을 줄임으로써 해결이 가능함.

![K-007](https://github.com/toy-p/Pocket-Map/assets/110343070/6d23707c-013e-47ba-8369-6fdd8d518897)


## 이슈

<!--
관련 이슈사항이 있다면 적어주세요.
-->
1. 메인 화면에서 주소 검색을 하지 않고, 뒤로가기 하였을 때, 카카오맵 화면에서 오류발생.
2. 마커 리스트에서 원하는 마커를 선택하였을 때, 주소 검색 창에 이전 검색하였던 주소가 유지되어 현재 마커의 주소를 나타내지 않음.
4. 새로운 마커 추가시에도 이전 검색하였던 주소가 유지되어 추가된 마커의 주소를 나타내지 않음.

## 기타

<!--
기타 사항이 있다면 적어주세요.
-->